### PR TITLE
Fix some of the tests on GPU-enabled systems

### DIFF
--- a/tests/test.step_05.py
+++ b/tests/test.step_05.py
@@ -134,9 +134,7 @@ def test_step_05():
         # Test forward pass with sample token IDs
         # Create a small batch of token IDs
         batch_size, seq_length = 2, 4
-        test_input = Tensor.constant(
-            [[1, 2, 3, 4], [5, 6, 7, 8]], dtype=DType.int64, device=CPU()
-        )
+        test_input = Tensor.constant([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=DType.int64)
 
         output = embeddings(test_input)
         results.append("✅ GPT2Embeddings forward pass executes without errors")
@@ -153,7 +151,7 @@ def test_step_05():
         # Verify output is not all zeros (embeddings should have values)
         import numpy as np
 
-        output_np = np.from_dlpack(output.to(CPU()))
+        output_np = np.from_dlpack(output.to(CPU()).cast(DType.float32))
         if not np.allclose(output_np, 0):
             results.append("✅ Output contains non-zero embedding values")
         else:

--- a/tests/test.step_06.py
+++ b/tests/test.step_06.py
@@ -146,7 +146,7 @@ def test_step_06():
         # Test forward pass with position indices
         # Create position indices for a sequence
         seq_length = 8
-        test_positions = Tensor.arange(seq_length, dtype=DType.int64, device=CPU())
+        test_positions = Tensor.arange(seq_length, dtype=DType.int64)
 
         output = pos_embeddings(test_positions)
         results.append("✅ GPT2PositionEmbeddings forward pass executes without errors")
@@ -163,7 +163,7 @@ def test_step_06():
         # Verify output is not all zeros (embeddings should have values)
         import numpy as np
 
-        output_np = np.from_dlpack(output.to(CPU()))
+        output_np = np.from_dlpack(output.to(CPU()).cast(DType.float32))
         if not np.allclose(output_np, 0):
             results.append("✅ Output contains non-zero embedding values")
         else:

--- a/tests/test.step_07.py
+++ b/tests/test.step_07.py
@@ -247,7 +247,7 @@ def test_step_07():
         batch_size = 2
         seq_length = 8
         test_input = Tensor.ones(
-            (batch_size, seq_length, config.n_embd), dtype=DType.float32, device=CPU()
+            (batch_size, seq_length, config.n_embd), dtype=DType.float32
         )
 
         output = mha(test_input)
@@ -271,7 +271,7 @@ def test_step_07():
 
         # Test _split_heads
         test_tensor = Tensor.ones(
-            (batch_size, seq_length, config.n_embd), dtype=DType.float32, device=CPU()
+            (batch_size, seq_length, config.n_embd), dtype=DType.float32
         )
         split_output = mha._split_heads(test_tensor, config.n_head, mha.head_dim)
         expected_split_shape = (batch_size, config.n_head, seq_length, mha.head_dim)

--- a/tests/test.step_09.py
+++ b/tests/test.step_09.py
@@ -233,9 +233,7 @@ def test_step_09():
         # Test forward pass
         batch_size = 2
         seq_length = 8
-        test_input = Tensor.ones(
-            (batch_size, seq_length, config.n_embd), dtype=DType.float32, device=CPU()
-        )
+        test_input = Tensor.ones((batch_size, seq_length, config.n_embd))
 
         output = block(test_input)
         results.append("✅ GPT2Block forward pass executes without errors")
@@ -250,7 +248,7 @@ def test_step_09():
             )
 
         # Check output contains non-zero values
-        output_np = np.from_dlpack(output.to(CPU()))
+        output_np = np.from_dlpack(output.to(CPU()).cast(DType.float32))
         if not np.allclose(output_np, 0):
             results.append("✅ Output contains non-zero values")
         else:

--- a/tests/test.step_10.py
+++ b/tests/test.step_10.py
@@ -272,7 +272,6 @@ def test_step_10():
             config.vocab_size,
             1,
             dtype=DType.int64,
-            device=CPU(),
         )[:test_len].reshape(
             (
                 batch_size,
@@ -293,7 +292,7 @@ def test_step_10():
             )
 
         # Check output contains non-zero values
-        output_np = np.from_dlpack(output.to(CPU()))
+        output_np = np.from_dlpack(output.to(CPU()).cast(DType.float32))
         if not np.allclose(output_np, 0):
             results.append("✅ Output contains non-zero values")
         else:

--- a/tests/test.step_11.py
+++ b/tests/test.step_11.py
@@ -141,7 +141,6 @@ def test_step_11():
         test_input = Tensor.ones(
             (batch_size, seq_length),
             dtype=DType.int64,
-            device=CPU(),
         )
 
         output = model(test_input)
@@ -156,7 +155,7 @@ def test_step_11():
                 f"❌ Output shape incorrect: expected {expected_shape}, got {output.shape}"
             )
 
-        output_np = np.from_dlpack(output.to(CPU()))
+        output_np = np.from_dlpack(output.to(CPU()).cast(DType.float32))
         if not np.allclose(output_np, 0):
             results.append("✅ Output contains non-zero values")
         else:


### PR DESCRIPTION
The tests for steps 5+ place the test tensors on the CPU, but on GPU-enabled systems the graph is by default placed on the GPU. This causes a mismatch on compilation, leading to these tests failing with cryptic errors on systems with NVIDIA or AMD GPUs.

Additionally, once the graph is run on the GPU, the default datatype is bfloat16 but that datatype isn't supported in NumPy. When results are read back into the NumPy array, these reads fail without an appropriate cast to float32 values.

This fixes these tests for steps 5, 6, 7, 9, 10, and 11 and enables them to run on GPU-equipped machines. Steps 8 and 12 have additional issues to fix, even when this casting is handled. They will be fixed later.

Fixes issue #12