### PR TITLE
Fix for test by renaming tokenize_text to encode_text

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,7 +15,7 @@ from main import (
     GPT2Block,
     MaxGPT2Model,
     MaxGPT2LMHeadModel,
-    tokenize_text,
+    encode_text,
     decode_tokens,
 )
 
@@ -261,13 +261,13 @@ class TestTokenizationFunctions:
     """Test tokenization and decoding functions."""
 
     @patch('main.GPT2Tokenizer')
-    def test_tokenize_text(self, mock_tokenizer_class):
-        """Test tokenize_text function."""
+    def test_encode_text(self, mock_tokenizer_class):
+        """Test encode_text function."""
         # Setup mock
         mock_tokenizer = Mock()
         mock_tokenizer.encode.return_value = [15496, 995]  # "Hello world"
 
-        result = tokenize_text("Hello world", mock_tokenizer, CPU(), max_length=128)
+        result = encode_text("Hello world", mock_tokenizer, CPU(), max_length=128)
 
         # Check that tokenizer.encode was called correctly
         mock_tokenizer.encode.assert_called_once_with("Hello world", max_length=128, truncation=True)


### PR DESCRIPTION
The `tokenize_text` function looks like it was renamed to `encode_text` during edits, but the `test_main.py` file still refers to the old name. This causes `pixi run test` to fail.

Renaming this got all tests to pass on my local machine.