### PR TITLE
lighten the darkmode background

### DIFF
--- a/book/theme/css/custom.css
+++ b/book/theme/css/custom.css
@@ -1261,7 +1261,7 @@ details:last-child {
 
 .warning {
   border: none;
-  background-color: #ffeba4;
+  background-color: #fff4cc;
   padding: 16px 40px;
   margin: 0 0 0 -8px;
   box-sizing: border-box;


### PR DESCRIPTION
This change matches docs.modular.com's darkmode background and also changes the warning notice color to match docsite in both dark and light mode.