### PR TITLE
Add book link to system requirements

### DIFF
--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -93,6 +93,8 @@ This tutorial assumes:
 - **Interest in understanding**: Curiosity matters more than prior transformer
   experience
 
+You'll need to meet the [system requirements](https://docs.modular.com/max/packages#system-requirements).
+
 Whether you're exploring MAX for the first time or deepening your understanding
 of model architecture, this tutorial provides hands-on experience you can apply
 to current projects and learning priorities.


### PR DESCRIPTION
Thanks for this tutorial! Working through it on Apple Silicon, I hit the [RuntimeError](https://github.com/modular/modular/blob/488875f1942392ca78380aa3512fcf1351cd2b66/max/python/max/engine/api.py#L423-L436) below
```
❌ ERRORS:
  - Failed to instantiate GPT2MLP: Failed to compile the model. Please file an issue, all models should be correct by construction and this error should have been caught during construction.
For more detailed failure information run with the environment variable `MODULAR_MAX_DEBUG=True`.
```
-----
Adding the env var didn't surface any more info
```
debug_s02 = { cmd = "python checks/check_step_02.py", env = { MODULAR_MAX_DEBUG = "True" } }
```

After digging around I found the instruction [here](https://docs.modular.com/max/packages/#system-requirements) to install the Metal toolchain with `xcodebuild -downloadComponent MetalToolchain`. This was the key! All `s02` checks passed ✅ 

The GPU Puzzles book has a more in-depth section on [Prerequisites](https://github.com/modular/mojo-gpu-puzzles/blob/main/book/src/howto.md#prerequisites), but I felt adding all that here would be duplication and crowd the content on this page.