### PR TITLE
Fix step_11 hint descendents->descendants

### DIFF
--- a/WEIGHT_LOADING.md
+++ b/WEIGHT_LOADING.md
@@ -51,7 +51,7 @@ from max.nn import Linear
 
 # Transpose weights for linear layers that correspond to Conv1D in HuggingFace
 max_model.to(device)
-for name, child in max_model.descendents:
+for name, child in max_model.descendants:
     if isinstance(child, Linear):
         if any(layer_name in name for layer_name in ['c_attn', 'c_proj', 'c_fc']):
             print(f"Transposing {name}: {child.weight.shape}")
@@ -93,7 +93,7 @@ device = CPU()
 max_model.load_state_dict(torch_model.state_dict())
 max_model.to(device)
 
-for name, child in max_model.descendents:
+for name, child in max_model.descendants:
     if isinstance(child, Linear):
         if any(layer_name in name for layer_name in ['c_attn', 'c_proj', 'c_fc']):
             child.weight = child.weight.T

--- a/book/src/step_11.md
+++ b/book/src/step_11.md
@@ -108,13 +108,13 @@ Load and transpose the weights:
 ```python
 max_model.load_state_dict(hf_model.state_dict())
 max_model.to(device)
-for name, child in max_model.descendents:
+for name, child in max_model.descendants:
     if isinstance(child, Linear):
         if any(layer_name in name for layer_name in ["c_attn", "c_proj", "c_fc"]):
             child.weight = child.weight.T
 ```
 
-The `descendents` property gives you all nested modules with their full paths.
+The `descendants` property gives you all nested modules with their full paths.
 Check each child's name for the Conv1D layers and transpose their weights.
 
 Initialize the tokenizer:
@@ -183,8 +183,7 @@ Run `pixi run s11` to verify your implementation.
 
 </details>
 
-**Congratulations!** You've completed built a complete GPT-2 implementation from
-scratch.
+**Congratulations!** You've built a complete GPT-2 implementation from scratch.
 
 If code verification passed, you can execute your `step_11.py` code with
 `pixi run gpt2`.

--- a/steps/step_11.py
+++ b/steps/step_11.py
@@ -17,6 +17,11 @@ Tasks:
 
 Run: pixi run s11
 """
+# TODO: Import required modules and components from prior steps
+# Hint: You'll need defaults() from max.tensor
+
+# TODO: Import GPT2LMHeadModel and GPT2Tokenizer HuggingFace transformers library
+# Hint: from transformers import GPT2LMHeadModel, GPT2Tokenizer
 
 
 def run_model() -> None:
@@ -46,7 +51,7 @@ def run_model() -> None:
 
     # TODO: Transpose weights for Linear layers
     # Hint: HuggingFace uses Conv1D which stores weights transposed
-    # Hint: for name, child in max_model.descendents:
+    # Hint: for name, child in max_model.descendants:
     #     if isinstance(child, Linear):
     #         if any(layer_name in name for layer_name in ["c_attn", "c_proj", "c_fc"]):
     #             print(f"Transposing {name}: {child.weight.shape}")


### PR DESCRIPTION
- Fixed hint in `step_11.py` and in docs: `descendents` -> `descendants`
- Fixed typo "You've ~completed~ built a complete GPT-2 implementation from scratch."
- Added hints to top of `step_11.py` regarding HuggingFace `transformers` and `defaults()`

```
# TODO: Import required modules and components from prior steps
# Hint: You'll need defaults() from max.tensor

# TODO: Import GPT2LMHeadModel and GPT2Tokenizer HuggingFace transformers library
# Hint: from transformers import GPT2LMHeadModel, GPT2Tokenizer
```